### PR TITLE
Enhance EXPLORATION desire FILTERING

### DIFF
--- a/src/agents/bdi/bdi_agent.ts
+++ b/src/agents/bdi/bdi_agent.ts
@@ -67,6 +67,9 @@ export class BDIAgent {
 
             // Update beliefs about crates based on the sensing event data
             this.beliefs.map.updateCrates(sensing.crates, sensing.positions);
+
+            // Record visit times for all spawn tiles currently in sensor range
+            this.beliefs.map.updateSpawnTilesVisitTimes(sensing.positions, Date.now());
             
             if (this.debug) console.log(
                 "[PERCEIVE] Sensing update — agents:", sensing.agents.length,

--- a/src/agents/bdi/bdi_agent.ts
+++ b/src/agents/bdi/bdi_agent.ts
@@ -68,8 +68,8 @@ export class BDIAgent {
             // Update beliefs about crates based on the sensing event data
             this.beliefs.map.updateCrates(sensing.crates, sensing.positions);
 
-            // Record visit times for all spawn tiles currently in sensor range
-            this.beliefs.map.updateSpawnTilesVisitTimes(sensing.positions, Date.now());
+            // Record sensing times for all spawn tiles currently in sensor range
+            this.beliefs.map.updateSpawnTilesSensingTimes(sensing.positions, Date.now());
             
             if (this.debug) console.log(
                 "[PERCEIVE] Sensing update — agents:", sensing.agents.length,

--- a/src/agents/bdi/belief/map_beliefs.ts
+++ b/src/agents/bdi/belief/map_beliefs.ts
@@ -13,8 +13,8 @@ export class MapBeliefs {
     private spawnTiles: Tile[] = [];                 // Precomputed on updateMap; map is static so this never changes
     private deliveryTiles: Tile[] = [];              // Precomputed on updateMap; map is static so this never changes
     
-    private crates = new Tracker<Crate>();                     // Latest-only store; eviction is handled by MapBeliefs.evict()
-    private spawnTilesVisitTimes = new Map<Position, number>();    // Keep track of when spawn tiles were last sensed, keyed as "x,y"
+    private crates = new Tracker<Crate>();                           // Latest-only store; eviction is handled by MapBeliefs.evict()
+    private spawnTilesSensingTimes = new Map<Position, number>();    // Keep track of when spawn tiles were last sensed, keyed as "x,y"
     
     /**
      * Initialize map beliefs from the given map info.
@@ -83,10 +83,9 @@ export class MapBeliefs {
         sensedPositions.forEach(position => {
             const tile = this.getTileAt(position);
             if (tile && tile.type === TILE_TYPE.SPAWN_POINT) {
-                this.spawnTilesVisitTimes.set(position, currentTime);
+                this.spawnTilesSensingTimes.set(position, currentTime);
             }
         });
-        console.log("[MAP BELIEFS] Updated spawn tile visit times:", this.spawnTilesVisitTimes);
     }
 
     /**
@@ -95,7 +94,7 @@ export class MapBeliefs {
      * @returns The timestamp of the last visit to the spawn tile, or undefined if never visited.
      */
     getSpawnTileVisitTime(position: Position): number | undefined {
-        return this.spawnTilesVisitTimes.get(position);
+        return this.spawnTilesSensingTimes.get(position);
     }
     /**
      * All parcel delivery tiles.

--- a/src/agents/bdi/belief/map_beliefs.ts
+++ b/src/agents/bdi/belief/map_beliefs.ts
@@ -14,7 +14,8 @@ export class MapBeliefs {
     private deliveryTiles: Tile[] = [];              // Precomputed on updateMap; map is static so this never changes
     
     private crates = new Tracker<Crate>();                           // Latest-only store; eviction is handled by MapBeliefs.evict()
-    private spawnTilesSensingTimes = new Map<Position, number>();    // Keep track of when spawn tiles were last sensed, keyed as "x,y"
+    private spawnTilesSensingTimes = new Map<string, number>();      // Keep track of when spawn tiles were last sensed, keyed as "x,y"
+
     
     /**
      * Initialize map beliefs from the given map info.
@@ -74,27 +75,27 @@ export class MapBeliefs {
     }
 
     /**
-     * Update the visit times for all spawn tiles based on the positions sensed.
+     * Update the sensing times for all spawn tiles based on the positions sensed.
      * @param sensedPositions Array of positions that are currently sensed.
-     * @param currentTime The current time to update the visit times.
+     * @param currentTime The current time to update the sensing times.
      */
-    updateSpawnTilesVisitTimes(sensedPositions: Position[], currentTime: number): void {
-        // For each sensed position, if it's a spawn tile, update its last visit time
+    updateSpawnTilesSensingTimes(sensedPositions: Position[], currentTime: number): void {
+        // For each sensed position, if it's a spawn tile, update its last sensing time
         sensedPositions.forEach(position => {
             const tile = this.getTileAt(position);
             if (tile && tile.type === TILE_TYPE.SPAWN_POINT) {
-                this.spawnTilesSensingTimes.set(position, currentTime);
+                this.spawnTilesSensingTimes.set(`${position.x},${position.y}`, currentTime);
             }
         });
     }
 
     /**
-     * Get the last visit time for a given spawn tile position, or undefined if it has never been visited.
+     * Get the last sensing time for a given spawn tile position, or undefined if it has never been sensed.
      * @param position The position of the spawn tile to query.
-     * @returns The timestamp of the last visit to the spawn tile, or undefined if never visited.
+     * @returns The timestamp of the last sensing of the spawn tile, or undefined if never sensed.
      */
-    getSpawnTileVisitTime(position: Position): number | undefined {
-        return this.spawnTilesSensingTimes.get(position);
+    getSpawnTilesSensingTime(position: Position): number | undefined {
+        return this.spawnTilesSensingTimes.get(`${position.x},${position.y}`);
     }
     /**
      * All parcel delivery tiles.

--- a/src/agents/bdi/belief/map_beliefs.ts
+++ b/src/agents/bdi/belief/map_beliefs.ts
@@ -1,21 +1,20 @@
 import type { GameMap, Tile } from "../../../models/map.js";
-import type { Agent } from "../../../models/agent.js";
 import type { Crate } from "../../../models/crate.js";
 import type { Position } from "../../../models/position.js";
 import type { IOTile, IOCrate } from "../../../models/djs.js";
 import { TILE_TYPE, type TileType } from "../../../models/tile_type.js";
 import { Tracker } from "./utils/tracker.js";
-import { manhattanDistance } from "../../../utils/metrics.js";
 
 /**
  * Beliefs about the static map layout and dynamic crate positions.
  */
 export class MapBeliefs {
-
-    private map: GameMap | null = null;             // Static map layout, set once at the start of the game
-    private spawnTiles: Tile[] = [];                // Precomputed on updateMap; map is static so this never changes
-    private deliveryTiles: Tile[] = [];             // Precomputed on updateMap; map is static so this never changes
-    private crates = new Tracker<Crate>();          // Latest-only store; eviction is handled by MapBeliefs.evict()
+    private map: GameMap | null = null;              // Static map layout, set once at the start of the game
+    private spawnTiles: Tile[] = [];                 // Precomputed on updateMap; map is static so this never changes
+    private deliveryTiles: Tile[] = [];              // Precomputed on updateMap; map is static so this never changes
+    
+    private crates = new Tracker<Crate>();                     // Latest-only store; eviction is handled by MapBeliefs.evict()
+    private spawnTilesVisitTimes = new Map<Position, number>();    // Keep track of when spawn tiles were last sensed, keyed as "x,y"
     
     /**
      * Initialize map beliefs from the given map info.
@@ -66,7 +65,7 @@ export class MapBeliefs {
         return tile !== null && tile.type !== TILE_TYPE.WALL;
     }
     
-    /** 
+    /**
      * All parcel spawn tiles.
      * @return An array of spawn tiles
      */
@@ -75,41 +74,35 @@ export class MapBeliefs {
     }
 
     /**
-     * Get the nearest spawn tile to the agent's last known position.
-     * @param agent The agent for which to find the nearest spawn tile.
-     * @returns The nearest spawn tile, or null if no free spawn tiles are available.
+     * Update the visit times for all spawn tiles based on the positions sensed.
+     * @param sensedPositions Array of positions that are currently sensed.
+     * @param currentTime The current time to update the visit times.
      */
-    getNearestSpawnTile(agent: Agent): Tile {
-        return this.getNearestTile(this.spawnTiles, agent);
+    updateSpawnTilesVisitTimes(sensedPositions: Position[], currentTime: number): void {
+        // For each sensed position, if it's a spawn tile, update its last visit time
+        sensedPositions.forEach(position => {
+            const tile = this.getTileAt(position);
+            if (tile && tile.type === TILE_TYPE.SPAWN_POINT) {
+                this.spawnTilesVisitTimes.set(position, currentTime);
+            }
+        });
+        console.log("[MAP BELIEFS] Updated spawn tile visit times:", this.spawnTilesVisitTimes);
     }
 
+    /**
+     * Get the last visit time for a given spawn tile position, or undefined if it has never been visited.
+     * @param position The position of the spawn tile to query.
+     * @returns The timestamp of the last visit to the spawn tile, or undefined if never visited.
+     */
+    getSpawnTileVisitTime(position: Position): number | undefined {
+        return this.spawnTilesVisitTimes.get(position);
+    }
     /**
      * All parcel delivery tiles.
      * @return An array of delivery tiles
      */
     getDeliveryTiles(): Tile[] {
         return this.deliveryTiles;
-    }
-
-    /**
-     * Get the nearest delivery tile to the agent's last known position.
-     * @param agent The agent for which to find the nearest delivery tile.
-     * @returns The nearest delivery tile.
-     */
-    getNearestDeliveryTile(agent: Agent): Tile {
-        return this.getNearestTile(this.deliveryTiles, agent);
-    }
-
-    /**
-     * Return the tile in `tiles` closest to the agent's last known position.
-     * Falls back to the first tile if the agent position is unknown.
-     */
-    private getNearestTile(tiles: Tile[], agent: Agent): Tile {
-        const agentPos = agent.lastPosition;
-        if (!agentPos) return tiles[0];
-        return tiles.reduce((nearest, tile) => {
-            return manhattanDistance(tile, agentPos) < manhattanDistance(nearest, agentPos) ? tile : nearest;
-        }, tiles[0]);
     }
 
     /**

--- a/src/agents/bdi/desire/desire_filter.ts
+++ b/src/agents/bdi/desire/desire_filter.ts
@@ -8,6 +8,7 @@ import type {
     GeneratedDesires,
 } from "../../../models/desires.js";
 import { manhattanDistance } from "../../../utils/metrics.js";
+import { MapBeliefs } from "../belief/map_beliefs.js";
 
 /**
  * Select the top desire out of all candidates generated this cycle.
@@ -46,7 +47,7 @@ export function getBestDesire(desires: GeneratedDesires, beliefs: Beliefs): Desi
     return filterExplore(
         explores,
         beliefs.agents.getCurrentMe()?.lastPosition ?? null,
-        beliefs.agents.getObservationDistance(),
+        beliefs.map
     );
 }
 
@@ -122,7 +123,10 @@ function scoreReachDesire(desire: ReachParcelDesire, beliefs: Beliefs): number {
  * Falls back to 0 when the agent position is unknown or nothing is being carried.
  * Basic heuristic — replace this function to improve goal selection in the future.
  */
-function scoreDeliverDesire(desire: DeliverParcelDesire, beliefs: Beliefs): number {
+function scoreDeliverDesire(
+    desire: DeliverParcelDesire, 
+    beliefs: Beliefs
+): number {
     const me = beliefs.agents.getCurrentMe();
     if (!me?.lastPosition) return 0;
 
@@ -134,23 +138,46 @@ function scoreDeliverDesire(desire: DeliverParcelDesire, beliefs: Beliefs): numb
 }
 
 /**
- * Select the best ExploreDesire: the nearest spawn tile outside the agent's observation range.
- * Falls back to the nearest overall if all spawn tiles are within range.
- * @param explores - All generated ExploreDesires
- * @param agentPos - The agent's current position, or null if unknown
- * @param observationDistance - The agent's observation radius in tiles, or null if unknown
- * @returns The selected ExploreDesire, or null if there are no candidates
+ * Select the best ExploreDesire using visit-time scoring: score = age / (distance + 1).
+ * Never-visited tiles score Infinity and always win. Among visited tiles, older and closer tiles score higher.
+ * Candidates are pre-filtered to those outside the agent's observation range; falls back to all tiles if none qualify.
  */
-export function filterExplore(explores: ExploreDesire[], agentPos: { x: number; y: number } | null, observationDistance: number | null,): ExploreDesire {
-    // Assumes always possible to explore
-    if (!agentPos || observationDistance === null) return explores[0];
-    // Manage ExploreDesires by prioritising the nearest spawn tile that is outside the agent's current observation range
-    const outOfRange = explores.filter(
-        d => manhattanDistance(d.target, agentPos) > observationDistance,
+export function filterExplore(
+    explores: ExploreDesire[],
+    agentPos: { x: number; y: number } | null,
+    mapBeliefs: MapBeliefs
+): ExploreDesire {
+    // If we don't know where we are, pick the first explore desire available
+    if (!agentPos) return explores[0];
+
+    // Score each candidate and pick the best one
+    const now = Date.now();
+    return explores.reduce((best, desire) =>
+        scoreExplore(desire, agentPos, mapBeliefs, now) > scoreExplore(best, agentPos, mapBeliefs, now) ? desire : best,
     );
-    const candidates = outOfRange.length > 0 ? outOfRange : explores;
-    // Select the nearest candidate
-    return candidates.reduce((nearest, d) =>
-        manhattanDistance(d.target, agentPos) < manhattanDistance(nearest.target, agentPos) ? d : nearest,
-    );
+}
+
+/**
+ * Score an ExploreDesire based on how long it's been since the target tile was last visited, 
+ * adjusted for distance: score = age / (distance + 1).
+ * Tiles that have never been visited score Infinity and will always be chosen over visited tiles.
+ * Among visited tiles, those that haven't been visited for a long time and are closer will score higher.
+ * @param desire The ExploreDesire to score, containing the target tile position.
+ * @param agentPos The current position of the agent, used to calculate distance. If null, the desire will score 0.
+ * @param mapBeliefs The agent's beliefs about the map, used to look up the last visit time for the target tile.
+ * @param now The current timestamp, used to calculate the age of the last visit.
+ * @returns A numeric score representing the desirability of exploring the target tile, where higher is better.
+ */
+function scoreExplore(
+    desire: ExploreDesire,
+    agentPos: { x: number; y: number },
+    mapBeliefs: MapBeliefs,
+    now: number
+): number {
+    // Get spawn tile distance and age since last visit
+    const distance = manhattanDistance(desire.target, agentPos);
+    const lastVisit = mapBeliefs.getSpawnTileVisitTime(desire.target);
+    const age = lastVisit !== undefined ? now - lastVisit : Infinity;
+
+    return age / (distance + 1);
 }

--- a/src/agents/bdi/desire/desire_filter.ts
+++ b/src/agents/bdi/desire/desire_filter.ts
@@ -138,8 +138,8 @@ function scoreDeliverDesire(
 }
 
 /**
- * Select the best ExploreDesire using visit-time scoring: score = age / (distance + 1).
- * Never-visited tiles score Infinity and always win. Among visited tiles, older and closer tiles score higher.
+ * Select the best ExploreDesire using sensing-time scoring: score = age / (distance + 1).
+ * Never-sensed tiles score Infinity and always win. Among sensed tiles, older and closer tiles score higher.
  * Candidates are pre-filtered to those outside the agent's observation range; falls back to all tiles if none qualify.
  */
 export function filterExplore(
@@ -158,14 +158,14 @@ export function filterExplore(
 }
 
 /**
- * Score an ExploreDesire based on how long it's been since the target tile was last visited, 
+ * Score an ExploreDesire based on how long it's been since the target tile was last sensed, 
  * adjusted for distance: score = age / (distance + 1).
- * Tiles that have never been visited score Infinity and will always be chosen over visited tiles.
- * Among visited tiles, those that haven't been visited for a long time and are closer will score higher.
+ * Tiles that have never been sensed score Infinity and will always be chosen over sensed tiles.
+ * Among sensed tiles, those that haven't been sensed for a long time and are closer will score higher.
  * @param desire The ExploreDesire to score, containing the target tile position.
  * @param agentPos The current position of the agent, used to calculate distance. If null, the desire will score 0.
- * @param mapBeliefs The agent's beliefs about the map, used to look up the last visit time for the target tile.
- * @param now The current timestamp, used to calculate the age of the last visit.
+ * @param mapBeliefs The agent's beliefs about the map, used to look up the last sensing time for the target tile.
+ * @param now The current timestamp, used to calculate the age of the last sensing.
  * @returns A numeric score representing the desirability of exploring the target tile, where higher is better.
  */
 function scoreExplore(
@@ -174,10 +174,12 @@ function scoreExplore(
     mapBeliefs: MapBeliefs,
     now: number
 ): number {
-    // Get spawn tile distance and age since last visit
+    // Get spawn tile distance and age since last sensing
     const distance = manhattanDistance(desire.target, agentPos);
-    const lastVisit = mapBeliefs.getSpawnTileVisitTime(desire.target);
-    const age = lastVisit !== undefined ? now - lastVisit : Infinity;
+    const lastSensing = mapBeliefs.getSpawnTilesSensingTime(desire.target);
+    // If the tile has never been sensed, assign it an infinite score to prioritize it above all else. 
+    // Otherwise, calculate the score based on age and distance.
+    const age = lastSensing !== undefined ? now - lastSensing : Infinity;
 
     return age / (distance + 1);
 }


### PR DESCRIPTION
close #6

Improve the exploration desire filtering by defining a score for each spawn tile: score = age / (distance + 1)
- Add in map beliefs a Map to keep track of last time a spawn tile was seen;
- At each sensing, update the beliefs
- Score each exploration desire