### PR TITLE
Implement spawn cluster priority

### DIFF
--- a/src/agents/bdi/bdi_agent.ts
+++ b/src/agents/bdi/bdi_agent.ts
@@ -33,8 +33,10 @@ export class BDIAgent {
         // Set game configuration in beliefs once received
         this.socket.on('config', (config : IOConfig) => {
             this.beliefs.setSettings(config);
-            const obsDist = this.beliefs.agents.getObservationDistance();
-            if (obsDist !== null) this.beliefs.map.computeClusterWeights(obsDist);
+
+            // If config change causes observation distance change, we need to recompute cluster weights for the map beliefs
+            const obsDist = this.beliefs.agents.getObservationDistance();                                                                                                                                                         
+            if (obsDist !== null) this.beliefs.map.computeClusterWeights(obsDist);                                                                                                                                                
         });
 
         // Running it makes it move every time it receives a sensing event, it works like a while loop
@@ -56,6 +58,11 @@ export class BDIAgent {
             //NOTE: currently the server for an NxM map sends width=N-1 and height=M-1, so we add 1 to both to get the correct dimensions.
             // This is a temporary workaround until the server is fixed to send the correct dimensions.
             this.beliefs.map.updateMap(width +1, height +1, tiles);
+
+            // Compute cluster weights for spawn tiles now that we have the map and observation distance (if already received in config)
+            const obsDist = this.beliefs.agents.getObservationDistance();
+            if (obsDist !== null) this.beliefs.map.computeClusterWeights(obsDist);
+            
             if (this.debug) console.log("[PERCEIVE] Map info received — width:", width, "| height:", height, "| tiles:", tiles.length);
         });
 

--- a/src/agents/bdi/bdi_agent.ts
+++ b/src/agents/bdi/bdi_agent.ts
@@ -33,6 +33,8 @@ export class BDIAgent {
         // Set game configuration in beliefs once received
         this.socket.on('config', (config : IOConfig) => {
             this.beliefs.setSettings(config);
+            const obsDist = this.beliefs.agents.getObservationDistance();
+            if (obsDist !== null) this.beliefs.map.computeClusterWeights(obsDist);
         });
 
         // Running it makes it move every time it receives a sensing event, it works like a while loop

--- a/src/agents/bdi/belief/map_beliefs.ts
+++ b/src/agents/bdi/belief/map_beliefs.ts
@@ -4,6 +4,7 @@ import type { Position } from "../../../models/position.js";
 import type { IOTile, IOCrate } from "../../../models/djs.js";
 import { TILE_TYPE, type TileType } from "../../../models/tile_type.js";
 import { Tracker } from "./utils/tracker.js";
+import { manhattanDistance } from "../../../utils/metrics.js";
 
 /**
  * Beliefs about the static map layout and dynamic crate positions.
@@ -15,7 +16,7 @@ export class MapBeliefs {
     
     private crates = new Tracker<Crate>();                           // Latest-only store; eviction is handled by MapBeliefs.evict()
     private spawnTilesSensingTimes = new Map<string, number>();      // Keep track of when spawn tiles were last sensed, keyed as "x,y"
-
+    private spawnTilesClusterWeights = new Map<string, number>();    // Keep track of how many spawn tiles are in the cluster of each spawn tile, keyed as "x,y"
     
     /**
      * Initialize map beliefs from the given map info.
@@ -94,9 +95,36 @@ export class MapBeliefs {
      * @param position The position of the spawn tile to query.
      * @returns The timestamp of the last sensing of the spawn tile, or undefined if never sensed.
      */
-    getSpawnTilesSensingTime(position: Position): number | undefined {
+    getSpawnTileSensingTime(position: Position): number | undefined {
         return this.spawnTilesSensingTimes.get(`${position.x},${position.y}`);
     }
+
+    /**
+     * Compute and cache a distance-weighted cluster weight for every spawn tile.
+     * Weight = Σ (observationDistance - dist(tile, neighbor) + 1) for each neighbor within range.
+     * Must be called once after observationDistance is known from the config event.
+     */
+    computeClusterWeights(observationDistance: number): void {
+        for (const tile of this.spawnTiles) {
+            const weight = this.spawnTiles.reduce((sum, neighbor) => {
+                const distance = manhattanDistance(tile, neighbor);
+                return distance <= observationDistance ? sum + (observationDistance - distance + 1) : sum;
+            }, 0);
+            this.spawnTilesClusterWeights.set(`${tile.x},${tile.y}`, weight);
+        }
+    }
+
+    /**
+     * Get the cluster weight for a given spawn tile position,
+     * which represents how many spawn tiles are sensed by standing on that tile.
+     * @param position The position of the spawn tile to query.
+     * @returns The cluster weight of the spawn tile, or 0 if not yet computed.
+     * Higher weights indicate tiles that can sense more spawn tiles when stood upon.
+     */
+    getSpawnTileClusterWeight(position: Position): number {
+        return this.spawnTilesClusterWeights.get(`${position.x},${position.y}`) ?? 0;
+    }
+
     /**
      * All parcel delivery tiles.
      * @return An array of delivery tiles

--- a/src/agents/bdi/belief/map_beliefs.ts
+++ b/src/agents/bdi/belief/map_beliefs.ts
@@ -26,20 +26,23 @@ export class MapBeliefs {
      * @returns void
      */
     updateMap(width: number, height: number, tiles: IOTile[]): void {
+        // Normalize tile types to strings — the server may send numeric values (e.g. 1) instead of strings ('1')
+        const normalizedTiles = tiles.map(t => ({ ...t, type: String(t.type) as TileType }));
+
         // Pre-fill with WALL so any tile absent from the server payload is treated as unwalkable
         const matrix = Array.from({ length: height }, () =>
             Array<TileType>(width).fill(TILE_TYPE.WALL)
         );
-        for (const t of tiles) {
+        for (const t of normalizedTiles) {
             matrix[t.y][t.x] = t.type;
         }
         this.map = { width, height, tiles: matrix };
 
         // Precompute static tile lists — map never changes after this point
-        this.spawnTiles = tiles
+        this.spawnTiles = normalizedTiles
             .filter(t => t.type === TILE_TYPE.SPAWN_POINT)
             .map(t => ({ x: t.x, y: t.y, type: t.type }));
-        this.deliveryTiles = tiles
+        this.deliveryTiles = normalizedTiles
             .filter(t => t.type === TILE_TYPE.DELIVERY_POINT)
             .map(t => ({ x: t.x, y: t.y, type: t.type }));
     }

--- a/src/agents/bdi/desire/desire_filter.ts
+++ b/src/agents/bdi/desire/desire_filter.ts
@@ -47,6 +47,7 @@ export function getBestDesire(desires: GeneratedDesires, beliefs: Beliefs): Desi
     return filterExplore(
         explores,
         beliefs.agents.getCurrentMe()?.lastPosition ?? null,
+        beliefs.agents.getObservationDistance(),
         beliefs.map
     );
 }
@@ -138,19 +139,20 @@ function scoreDeliverDesire(
 }
 
 /**
- * Select the best ExploreDesire using sensing-time scoring: score = age / (distance + 1).
- * Never-sensed tiles score Infinity and always win. Among sensed tiles, older and closer tiles score higher.
- * Candidates are pre-filtered to those outside the agent's observation range; falls back to all tiles if none qualify.
+ * Select the best ExploreDesire using cluster-weighted sensing-age scoring:
+ *   score = clusterWeight * age / (distance + 1)
+ * Candidates are pre-filtered to those outside observation range; falls back to all tiles if none qualify.
  */
 export function filterExplore(
     explores: ExploreDesire[],
     agentPos: { x: number; y: number } | null,
+    observationDistance: number | null,
     mapBeliefs: MapBeliefs
 ): ExploreDesire {
-    // If we don't know where we are, pick the first explore desire available
+    // If we don't know our position, return the first explore desire
     if (!agentPos) return explores[0];
-
-    // Score each candidate and pick the best one
+    
+    // Weight each explore desire and pick the one with the highest score
     const now = Date.now();
     return explores.reduce((best, desire) =>
         scoreExplore(desire, agentPos, mapBeliefs, now) > scoreExplore(best, agentPos, mapBeliefs, now) ? desire : best,
@@ -176,10 +178,14 @@ function scoreExplore(
 ): number {
     // Get spawn tile distance and age since last sensing
     const distance = manhattanDistance(desire.target, agentPos);
-    const lastSensing = mapBeliefs.getSpawnTilesSensingTime(desire.target);
+    const lastSensing = mapBeliefs.getSpawnTileSensingTime(desire.target);
+    
     // If the tile has never been sensed, assign it an infinite score to prioritize it above all else. 
     // Otherwise, calculate the score based on age and distance.
     const age = lastSensing !== undefined ? now - lastSensing : Infinity;
 
-    return age / (distance + 1);
+    // Get the cluster weight for the target tile
+    const clusterWeight = mapBeliefs.getSpawnTileClusterWeight(desire.target);
+    const weight = clusterWeight > 0 ? clusterWeight : 1;
+    return weight * age / (distance + 1);
 }


### PR DESCRIPTION
Now, each explore desire is also weighted by how many other spawn points are sensed from that tile. This allows to first prioritise cluster of spawn tiles