### PR TITLE
Add enemy spatial heatmap

### DIFF
--- a/src/agents/bdi/belief/agent_beliefs.ts
+++ b/src/agents/bdi/belief/agent_beliefs.ts
@@ -18,7 +18,9 @@ export class AgentBeliefs {
     private enemiesMemory = new Memory<Agent>(1_000, 20);   // Memory of enemy agents, keyed by ID, with TTL-based eviction
     private playerSettings: PlayerSettings | null = null;   // Player settings from config
 
-    private readonly POSITION_STALE_THRESHOLD_MS = 2_000; // Discard agent positions not refreshed within this window to avoid blocking on ghost agents
+    private readonly POSITION_STALE_THRESHOLD_MS = 2_000;   // Discard agent positions not refreshed within this window to avoid blocking on ghost agents
+    private static readonly HEAT_SIGMA = 3;                 // Spatial spread (tiles): controls how far an enemy's presence radiates
+    private static readonly HEAT_TAU   = 5_000;             // Time decay constant (ms): matches enemiesMemory TTL
 
     // Memory management - EvictInterval prevents the agent from evicting stale beliefs too frequently,
     private lastEvict = 0;                          // Timestamp of the last eviction of stale beliefs
@@ -194,6 +196,42 @@ export class AgentBeliefs {
      */
     getCarryCapacity(): number | null {
         return this.playerSettings?.carry_capacity ?? null;
+    }
+
+    /**
+     * Heat contribution at `pos` from a single enemy, computed from its observation history.
+     * Each observation contributes exp(-d²/2σ²) * exp(-age/τ), combining spatial and temporal decay.
+     * @param enemyId The ID of the enemy agent to compute heat for.
+     * @param pos The position at which to evaluate the heat.
+     * @param now Current timestamp in ms; defaults to Date.now().
+     * @returns Total heat contribution from this enemy at pos (0 when no history exists).
+     */
+    heatFromEnemy(enemyId: string, pos: Position, now = Date.now()): number {
+        const history = this.enemiesMemory.getHistory(enemyId);
+        let heat = 0;
+        for (const obs of history) {
+            const ePos = obs.value.lastPosition;
+            if (!ePos) continue;
+            const d = Math.abs(pos.x - ePos.x) + Math.abs(pos.y - ePos.y);
+            const spatialDecay = Math.exp(-(d * d) / (2 * AgentBeliefs.HEAT_SIGMA * AgentBeliefs.HEAT_SIGMA));
+            const timeDecay = Math.exp(-(now - obs.seenAt) / AgentBeliefs.HEAT_TAU);
+            heat += spatialDecay * timeDecay;
+        }
+        return heat;
+    }
+
+    /**
+     * Aggregate enemy heat at `pos` across all currently-tracked enemies.
+     * Used by the EXPLORE scorer to penalise spawn tiles near recent enemy positions.
+     * @param pos The position at which to evaluate total enemy heat.
+     * @returns Sum of per-enemy heat contributions at pos.
+     */
+    getEnemyHeatAt(pos: Position): number {
+        const now = Date.now();
+        return this.enemies.getCurrentAll().reduce(
+            (sum, enemy) => sum + this.heatFromEnemy(enemy.id, pos, now),
+            0
+        );
     }
 
     /**

--- a/src/agents/bdi/desire/desire_sorter.ts
+++ b/src/agents/bdi/desire/desire_sorter.ts
@@ -8,7 +8,7 @@ import type {
 } from "../../../models/desires.js";
 import type { Position } from "../../../models/position.js";
 import { posKey, bfsDistancesFrom } from "../../../utils/metrics.js";
-import { MapBeliefs } from "../belief/map_beliefs.js";
+import { MapBeliefs } from "../belief/map_beliefs.js"; // used for static isStaticWalkable
 import { IntentionQueue } from "../../../models/intentions.js";
 
 
@@ -66,7 +66,7 @@ export function getIntentionQueue(desires: GeneratedDesires, beliefs: Beliefs): 
     const explores = (desires.get("EXPLORE") ?? []) as ExploreDesire[];
     const now = Date.now();
     for (const desire of explores) {
-        queue.push({ desire, score: scoreExplore(desire, meDist, beliefs.map, now) });
+        queue.push({ desire, score: scoreExplore(desire, meDist, beliefs, now) });
     }
 
     // Sort by priority tier first, then by score within the same tier
@@ -130,23 +130,26 @@ function scoreDeliverDesire(
 
 /**
  * Score an ExploreDesire based on how long it's been since the target tile was last sensed,
- * adjusted for distance: score = clusterWeight * age / (distance + 1).
+ * adjusted for distance: score = clusterWeight * age / (distance + 1) / (1 + enemyHeat).
  * Tiles that have never been sensed score Infinity and will always be chosen over sensed tiles.
  * Among sensed tiles, those that haven't been sensed for a long time and are closer will score higher.
+ * The enemy heat factor penalises tiles near recently-observed enemies.
  */
 function scoreExplore(
     desire: ExploreDesire,
     meDist: Map<string, number>,
-    mapBeliefs: MapBeliefs,
+    beliefs: Beliefs,
     now: number,
 ): number {
     const distance = meDist.get(posKey(desire.target));
     if (distance === undefined) return 0; // unreachable
 
-    const lastSensing = mapBeliefs.getSpawnTileSensingTime(desire.target);
+    const lastSensing = beliefs.map.getSpawnTileSensingTime(desire.target);
     const age = lastSensing !== undefined ? now - lastSensing : Infinity;
 
-    const clusterWeight = mapBeliefs.getSpawnTileClusterWeight(desire.target);
+    const clusterWeight = beliefs.map.getSpawnTileClusterWeight(desire.target);
     const weight = clusterWeight > 0 ? clusterWeight : 1;
-    return weight * age / (distance + 1);
+
+    const heat = beliefs.agents.getEnemyHeatAt(desire.target);
+    return weight * age / (distance + 1) / (1 + heat);
 }

--- a/src/agents/bdi/plan/pddl/solver.ts
+++ b/src/agents/bdi/plan/pddl/solver.ts
@@ -39,16 +39,16 @@ export function localSolver(pddlDomain: string, pddlProblem: string, log: Logger
     return output;
 }
 
-async function onlineSolver(pddlDomain: string, pddlProblem: string, debug: boolean): Promise<PddlPlanStep[]> {
+async function onlineSolver(pddlDomain: string, pddlProblem: string, logger: Logger): Promise<PddlPlanStep[]> {
     try {
         const startedAt = Date.now();
-        debug && console.log("[PDDL SOLVER] Sending request to online solver");
+        logger.debug("[PDDL SOLVER] Sending request to online solver");
         const result = await onlineSolverLib(pddlDomain, pddlProblem);
-        debug && console.log(`[PDDL SOLVER] Online solver result ready in ${Date.now() - startedAt}ms`);
+        logger.debug(`[PDDL SOLVER] Online solver result ready in ${Date.now() - startedAt}ms`);
         if (!result) return [];
         return result as PddlPlanStep[];
     } catch (err) {
-        console.error("[PDDL SOLVER] Online solver error:", err);
+        logger.error("[PDDL SOLVER] Online solver error:", err);
         return [];
     }
 }
@@ -57,13 +57,14 @@ async function onlineSolver(pddlDomain: string, pddlProblem: string, debug: bool
  * Select the solver to use based on the PAAS_HOST env var.
  * If PAAS_HOST is set, use the online solver; otherwise use the local binary.
  * Decision is made once at startup.
+ * @param log Logger instance to forward to the chosen solver.
  */
-export function selectSolver(debug: boolean): (domain: string, problem: string) => Promise<PddlPlanStep[]> {
+export function selectSolver(log: Logger): (domain: string, problem: string) => Promise<PddlPlanStep[]> {
     const paasHost = process.env.PAAS_HOST;
     if (paasHost) {
         console.log(`[PDDL SOLVER] Online solver enabled (PAAS_HOST=${paasHost})`);
-        return (domain, problem) => onlineSolver(domain, problem, debug);
+        return (domain, problem) => onlineSolver(domain, problem, log);
     }
     console.log("[PDDL SOLVER] Local solver in use");
-    return async (domain, problem) => parsePlanString(localSolver(domain, problem, debug));
+    return async (domain, problem) => parsePlanString(localSolver(domain, problem, log));
 }

--- a/src/agents/bdi/plan/pddl_planner.ts
+++ b/src/agents/bdi/plan/pddl_planner.ts
@@ -38,7 +38,7 @@ export class PddlPlanner {
     ) {
         this.log = createLogger("pddl", agentId);
         this.domain = readFileSync(CRATE_DOMAIN_PATH, "utf8");
-        this.solve = selectSolver(debug);
+        this.solve = selectSolver(this.log);
     }
 
     /**


### PR DESCRIPTION
Add a new "enemy heat" mechanism to the agent's belief and desire system, enhancing how the agent evaluates exploration targets by factoring in the recent presence of enemies. It also refactors the PDDL planner's solver selection to use a logger for improved debugging and error reporting. (Closes #36)
