### PR TITLE
Fix PPDL; Add problem caching

### DIFF
--- a/src/agents/bdi/belief/utils/crate_block.ts
+++ b/src/agents/bdi/belief/utils/crate_block.ts
@@ -49,6 +49,7 @@ export function findCrateSegment(
     from: Position,
     target: Position,
 ): CrateSegment | null {
+    // Get all currently believed crates with known positions
     const crates: LocatedCrate[] = beliefs.map.getCurrentCrates().flatMap(c =>
         c.lastPosition ? [{ id: c.id, position: c.lastPosition }] : [],
     );
@@ -59,7 +60,7 @@ export function findCrateSegment(
     const path = pathThroughPushableCrates(beliefs, from, target);
     if (!path) return null;
 
-    // Find the first (ENTRY) and last (EXIT) indices where the path crosses a crate tile
+    // Find the first and last indices where the path crosses a crate tile
     let firstIdx = -1;
     let lastIdx = -1;
     for (let i = 0; i < path.length; i++) {

--- a/src/agents/bdi/belief/utils/crate_block.ts
+++ b/src/agents/bdi/belief/utils/crate_block.ts
@@ -3,6 +3,8 @@ import { posKey } from "../../../../utils/metrics.js";
 import type { Beliefs } from "../beliefs.js";
 import type { Position } from "../../../../models/position.js";
 import type { NavigationDesire } from "../../../../models/desires.js";
+import type { LocatedCrate } from "../../../../models/crate.js";
+import type { CrateSegment } from "../../../../models/plan.js";
 
 /**
  * Check whether any currently believed crate blocks the direct path from `from` to `desire.target`.
@@ -46,8 +48,8 @@ export function findCrateSegment(
     beliefs: Beliefs,
     from: Position,
     target: Position,
-): { entry: Position; exit: Position; clusterCrates: { id: string; position: Position }[] } | null {
-    const crates = beliefs.map.getCurrentCrates().flatMap(c =>
+): CrateSegment | null {
+    const crates: LocatedCrate[] = beliefs.map.getCurrentCrates().flatMap(c =>
         c.lastPosition ? [{ id: c.id, position: c.lastPosition }] : [],
     );
     if (crates.length === 0) return null;

--- a/src/agents/bdi/belief/utils/crate_block.ts
+++ b/src/agents/bdi/belief/utils/crate_block.ts
@@ -1,4 +1,4 @@
-import { pathIgnoring } from "../../plan/navigation/a_star.js";
+import { pathIgnoring, pathThroughPushableCrates } from "../../plan/navigation/a_star.js";
 import { posKey } from "../../../../utils/metrics.js";
 import type { Beliefs } from "../beliefs.js";
 import type { Position } from "../../../../models/position.js";
@@ -28,6 +28,68 @@ export function detectCrateBlock(
 
     const crateIds = crates.filter(c => crateKeys.has(posKey(c.position))).map(c => c.id);
     return crateIds.length > 0 ? crateIds : null;
+}
+
+/**
+ * Find the contiguous crate-blocked segment on the push-aware path from `from` to `target`.
+ * Uses `pathThroughPushableCrates` so it only routes through crates that are single-step
+ * pushable in the direction of travel — immovable crates are treated as walls, causing the
+ * search to naturally select an alternative path that can actually be cleared.
+ *
+ * @returns An object containing:
+ * - `entry`: the position just before the first crate tile (or `from` if path starts on a crate)
+ * - `exit`: the position just after the last crate tile (or `target` if path ends on a crate)
+ * - `clusterCrates`: an array of all crates within the bounding box of entry+exit+on-path crate tiles, padded by 1
+ *
+ */
+export function findCrateSegment(
+    beliefs: Beliefs,
+    from: Position,
+    target: Position,
+): { entry: Position; exit: Position; clusterCrates: { id: string; position: Position }[] } | null {
+    const crates = beliefs.map.getCurrentCrates().flatMap(c =>
+        c.lastPosition ? [{ id: c.id, position: c.lastPosition }] : [],
+    );
+    if (crates.length === 0) return null;
+
+    // Push-aware path: only routes through crates whose push destination is a free crate-space.
+    // Immovable crates (wall behind them in travel direction) are treated as walls.
+    const path = pathThroughPushableCrates(beliefs, from, target);
+    if (!path) return null;
+
+    // Find the first (ENTRY) and last (EXIT) indices where the path crosses a crate tile
+    let firstIdx = -1;
+    let lastIdx = -1;
+    for (let i = 0; i < path.length; i++) {
+        if (beliefs.map.isCrateAt(path[i])) {
+            if (firstIdx === -1) firstIdx = i;
+            lastIdx = i;
+        }
+    }
+    if (firstIdx === -1) return null; // push-aware path avoided all crates — not actually blocked
+
+    // Entry: tile just before the first crate tile (or `from` if path starts on a crate)
+    const entry: Position = firstIdx === 0 ? from : path[firstIdx - 1];
+    // Exit: tile just after the last crate tile (or `target` if path ends on a crate)
+    const exit: Position = lastIdx === path.length - 1 ? target : path[lastIdx + 1];
+
+    // Cluster cache key: all crates within the bounding box of entry+exit+on-path crate tiles, padded by 1
+    const keyTiles: Position[] = [entry, exit];
+    for (let i = firstIdx; i <= lastIdx; i++) {
+        if (beliefs.map.isCrateAt(path[i])) keyTiles.push(path[i]);
+    }
+    const size = beliefs.map.getMapSize();
+    const minX = Math.max(0, Math.min(...keyTiles.map(p => p.x)) - 1);
+    const minY = Math.max(0, Math.min(...keyTiles.map(p => p.y)) - 1);
+    const maxX = size ? Math.min(size.width - 1, Math.max(...keyTiles.map(p => p.x)) + 1) : Math.max(...keyTiles.map(p => p.x)) + 1;
+    const maxY = size ? Math.min(size.height - 1, Math.max(...keyTiles.map(p => p.y)) + 1) : Math.max(...keyTiles.map(p => p.y)) + 1;
+
+    const clusterCrates = crates.filter(c =>
+        c.position.x >= minX && c.position.x <= maxX &&
+        c.position.y >= minY && c.position.y <= maxY,
+    );
+
+    return { entry, exit, clusterCrates };
 }
 
 /**

--- a/src/agents/bdi/plan/navigation/a_star.ts
+++ b/src/agents/bdi/plan/navigation/a_star.ts
@@ -89,6 +89,37 @@ export function pathIgnoring(
 }
 
 /**
+ * Find a path from `from` to `to` that may pass through crate tiles, but only those where the
+ * crate is single-step pushable in the direction of travel — i.e. the tile beyond the crate
+ * (in the same direction) is a crate-space and currently free.
+ * This matches the PDDL domain's push precondition exactly, so the returned path is guaranteed
+ * to contain only crates the solver can actually clear. Crates that cannot be pushed are treated
+ * as walls, causing A* to route around them (or to another viable path).
+ * A small penalty is added to each crate tile so the search naturally prefers fewer pushes
+ * when multiple viable paths exist.
+ */
+export function pathThroughPushableCrates(
+    beliefs: Beliefs,
+    from: Position,
+    to: Position,
+): Position[] | null {
+    const crateSpaces = new Set(beliefs.map.getCrateSpaceTiles().map(t => posKey(t)));
+    const CRATE_PUSH_PENALTY = 4;
+
+    return aStar(
+        from, to,
+        (f, t) => {
+            if (beliefs.map.isWalkable(f, t)) return true;
+            if (!beliefs.map.isCrateAt(t)) return false;
+            // Crate at `t` entered from direction (t-f): push destination is one tile further
+            const beyond = { x: t.x + (t.x - f.x), y: t.y + (t.y - f.y) };
+            return crateSpaces.has(posKey(beyond)) && !beliefs.map.isCrateAt(beyond);
+        },
+        (_, t) => 1 + (beliefs.map.isCrateAt(t) ? CRATE_PUSH_PENALTY : 0),
+    );
+}
+
+/**
  * Compute the steps to move from `from` to `to`, treating `blockedTile` as an impassable obstacle.
  * Used for crate-block detection: proves a target is unreachable if the blocked tile is not cleared.
  * @param beliefs Current beliefs, used to check walkability and tile penalties.

--- a/src/agents/bdi/plan/pddl/problem_builder.ts
+++ b/src/agents/bdi/plan/pddl/problem_builder.ts
@@ -29,10 +29,13 @@ export function buildProblem(target: Position, beliefs: Beliefs, from?: Position
 
     // Convert to integer the start position to avoid issues with PDDL parsing (e.g. t_3.0_5.0 vs t_3_5)
     let me_x: number, me_y: number;
+    // If an explicit start position is provided, use it
     if (from) {
         me_x = Math.round(from.x);
         me_y = Math.round(from.y);
-    } else {
+    }
+    // Otherwise, use the agent's current position from beliefs 
+    else {
         const me = beliefs.agents.getCurrentMe();
         if (!me?.lastPosition) return "";
         me_x = Math.round(me.lastPosition.x);

--- a/src/agents/bdi/plan/pddl/problem_builder.ts
+++ b/src/agents/bdi/plan/pddl/problem_builder.ts
@@ -13,22 +13,31 @@ export const ADJACENCY_DIRS = [
 ] as const;
 
 /**
- * Build a PDDL problem string that asks the solver to navigate the agent from its current
- * position to `target`, pushing any blocking crates out of the way.
- * @param target The tile the agent must reach (the navigation desire's target position).
- * @param beliefs Current agent beliefs, used for map layout, crate positions, and agent position.
+ * Build a PDDL problem string that asks the solver to navigate from `from` (or the agent's
+ * current position when omitted) to `target`, pushing any blocking crates out of the way.
+ * @param target The tile the agent must reach.
+ * @param beliefs Current agent beliefs, used for map layout and crate positions.
+ * @param from Optional explicit start position (used to anchor the problem at a crate-cluster
+ *   entry tile rather than the live agent position, enabling caching of the maneuver).
+ *   When omitted, falls back to the agent's current position from beliefs.
  * @returns A PDDL problem string, or an empty string if required beliefs are unavailable.
  */
-export function buildProblem(target: Position, beliefs: Beliefs): string {
-    // If the map size or agent position is not yet available, we cannot build a valid problem
+export function buildProblem(target: Position, beliefs: Beliefs, from?: Position): string {
+    // If the map size is not yet available, we cannot build a valid problem
     const size = beliefs.map.getMapSize();
     if (!size) return "";
-    const me = beliefs.agents.getCurrentMe();
-    if (!me?.lastPosition) return "";
 
-    // Convert to integer the agent position to avoid issues with PDDL parsing (e.g. t_3.0_5.0 vs t_3_5)
-    const me_x = Math.round(me.lastPosition.x);
-    const me_y = Math.round(me.lastPosition.y);
+    // Convert to integer the start position to avoid issues with PDDL parsing (e.g. t_3.0_5.0 vs t_3_5)
+    let me_x: number, me_y: number;
+    if (from) {
+        me_x = Math.round(from.x);
+        me_y = Math.round(from.y);
+    } else {
+        const me = beliefs.agents.getCurrentMe();
+        if (!me?.lastPosition) return "";
+        me_x = Math.round(me.lastPosition.x);
+        me_y = Math.round(me.lastPosition.y);
+    }
 
     // Generate the list of all non-wall tiles for object declarations and adjacency predicates
     const { width: mapWidth, height: mapHeight } = size;

--- a/src/agents/bdi/plan/pddl/solver.ts
+++ b/src/agents/bdi/plan/pddl/solver.ts
@@ -1,42 +1,59 @@
-import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { execFile as execFileCb } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import type { Logger } from "../../../../utils/logger.js";
 import onlineSolverLib from "@unitn-asa/pddl-client/src/PddlOnlineSolver.js";
 import type { PddlPlanStep } from "./response_parser.js";
 import { parsePlanString } from "./response_parser.js";
 
+const execFile = promisify(execFileCb);
 const SOLVER_PATH = join(homedir(), ".planutils", "bin", "dual-bfws-ffparser");
-const DOMAIN_FILE = "/tmp/domain.pddl";
-const PROBLEM_FILE = "/tmp/problem.pddl";
-const PLAN_FILE = "/tmp/plan";
 
-export function localSolver(pddlDomain: string, pddlProblem: string, log: Logger): string {
+/**
+ * Run the local PDDL solver asynchronously in an isolated temp directory.
+ * Using a per-call temp dir prevents file collisions when multiple agents fall back to PDDL
+ * concurrently (the old fixed /tmp/domain.pddl paths would be clobbered in that case).
+ */
+export async function localSolver(pddlDomain: string, pddlProblem: string, log: Logger): Promise<string> {
     const startedAt = Date.now();
-    writeFileSync(DOMAIN_FILE, pddlDomain);
-    writeFileSync(PROBLEM_FILE, pddlProblem);
-    // Remove any stale plan from a previous run
-    if (existsSync(PLAN_FILE)) unlinkSync(PLAN_FILE);
+    const tmpDir = mkdtempSync(join(tmpdir(), "pddl-"));
+    const domainFile = join(tmpDir, "domain.pddl");
+    const problemFile = join(tmpDir, "problem.pddl");
+    const planFile = join(tmpDir, "plan");
+
+    writeFileSync(domainFile, pddlDomain);
+    writeFileSync(problemFile, pddlProblem);
 
     log.debug("Starting local solver");
 
-    const result = spawnSync(SOLVER_PATH, [DOMAIN_FILE, PROBLEM_FILE], { cwd: "/tmp" });
-
-    log.debug(`Solver process exited with code ${result.status} and signal ${result.signal}`);
-    // dual-bfws (LAPKT) writes the plan to plan.ipc, not stdout
-    if (existsSync(PLAN_FILE)) {
-        log.debug(`Plan file found, reading result from ${PLAN_FILE}`);
-        const plan = readFileSync(PLAN_FILE, "utf8");
-        unlinkSync(PLAN_FILE);
-        log.debug(`Result ready in ${Date.now() - startedAt}ms`);
-        return plan;
+    let stdout = "";
+    try {
+        const result = await execFile(SOLVER_PATH, [domainFile, problemFile], { cwd: tmpDir });
+        stdout = result.stdout ?? "";
+        log.debug("Solver process exited successfully");
+    } catch (err: any) {
+        // dual-bfws (LAPKT) may exit with non-zero even when it successfully writes a plan file
+        stdout = err?.stdout ?? "";
+        log.debug(`Solver process exited with code ${err?.code}`);
     }
 
-    // Fallback: parse plan from stdout
-    const output = result.stdout?.toString() ?? "";
-    log.debug(`Result ready in ${Date.now() - startedAt}ms`);
-    return output;
+    try {
+        // dual-bfws (LAPKT) writes the plan to plan.ipc, not stdout
+        if (existsSync(planFile)) {
+            log.debug(`Plan file found, reading result from ${planFile}`);
+            const plan = readFileSync(planFile, "utf8");
+            log.debug(`Result ready in ${Date.now() - startedAt}ms`);
+            return plan;
+        }
+
+        // Fallback: parse plan from stdout
+        log.debug(`Result ready in ${Date.now() - startedAt}ms`);
+        return stdout;
+    } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
+    }
 }
 
 async function onlineSolver(pddlDomain: string, pddlProblem: string, logger: Logger): Promise<PddlPlanStep[]> {
@@ -66,5 +83,5 @@ export function selectSolver(log: Logger): (domain: string, problem: string) => 
         return (domain, problem) => onlineSolver(domain, problem, log);
     }
     console.log("[PDDL SOLVER] Local solver in use");
-    return async (domain, problem) => parsePlanString(localSolver(domain, problem, log));
+    return async (domain, problem) => parsePlanString(await localSolver(domain, problem, log));
 }

--- a/src/agents/bdi/plan/pddl_planner.ts
+++ b/src/agents/bdi/plan/pddl_planner.ts
@@ -31,6 +31,10 @@ export class PddlPlanner {
     private static readonly WAIT_MAX_MS = 1_500;
     private static readonly BLOCKED_TTL_MS = 1_000;
     private static readonly RETRY_LIMIT = 2;
+    private static readonly CACHE_SIZE = 32;
+
+    /** Keyed by `entry|exit|sortedCratePositions`. Stores the parsed move/push steps (no terminal). */
+    private readonly maneuverCache = new Map<string, PlanStep[]>();
 
     constructor(
         private readonly beliefs: Beliefs,
@@ -69,6 +73,56 @@ export class PddlPlanner {
 
         this.log.debug(`Plan ready: ${steps.length} step(s)`);
         return { source: "pddl", steps, cursor: 0, target: intention };
+    }
+
+    /**
+     * Solve the crate-clearing maneuver from `entry` to `exit` using PDDL, with a cache.
+     * The PDDL problem uses the full map (no windowing) but anchors start=entry, goal=exit —
+     * decoupling the maneuver from the agent's distant position and delivery target. This lets
+     * the cache key (`entry + exit + nearby crate positions`) remain stable while the agent
+     * approaches the cluster along the A* prefix, so moving 1 tile toward the cluster is a hit.
+     * @param entry Tile adjacent to the crate cluster; PDDL start.
+     * @param exit Tile just past the cluster; PDDL goal.
+     * @param clusterCrates Crates in the cluster bounding box, used to compute the cache key.
+     * @returns Parsed move/push steps (no terminal), or null if the solver fails.
+     */
+    async solveManeuver(
+        entry: Position,
+        exit: Position,
+        clusterCrates: { id: string; position: Position }[],
+    ): Promise<PlanStep[] | null> {
+        // Build the cache key from entry+exit+cluster crate positions
+        const key = [
+            `${entry.x},${entry.y}`,
+            `${exit.x},${exit.y}`,
+            clusterCrates.map(c => `${c.position.x},${c.position.y}`).sort().join(","),
+        ].join("|");
+        
+        // Check cache for existing solution before invoking the solver
+        const cached = this.maneuverCache.get(key);
+        if (cached) {
+            this.log.debug("Maneuver cache hit");
+            return [...cached];
+        }
+        
+        // If not cached, build the problem and solve it
+        const problem = buildProblem(exit, this.beliefs, entry);
+        if (!problem) return null;
+        const raw = await this.solve(this.domain, problem);
+        const steps = parsePddlPlan(raw);
+        if (steps.length === 0) {
+            this.log.debug("Solver returned no steps for maneuver");
+            return null;
+        }
+
+        // Evict oldest entry (FIFO) when the cache is full
+        if (this.maneuverCache.size >= PddlPlanner.CACHE_SIZE) {
+            const oldest = this.maneuverCache.keys().next().value;
+            if (oldest !== undefined) this.maneuverCache.delete(oldest);
+        }
+        this.maneuverCache.set(key, steps);
+        this.log.debug(`Maneuver cached (${steps.length} steps, cache size: ${this.maneuverCache.size})`);
+        return [...steps];
     }
 
     /**

--- a/src/agents/bdi/plan/pddl_planner.ts
+++ b/src/agents/bdi/plan/pddl_planner.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { Beliefs } from "../belief/beliefs.js";
 import type { NavigationDesire } from "../../../models/desires.js";
-import type { Plan, PlanStep } from "../../../models/plan.js";
+import type { Plan, PlanStep, CrateSegment } from "../../../models/plan.js";
 import type { Position } from "../../../models/position.js";
 import { buildProblem } from "./pddl/problem_builder.js";
 import { parsePddlPlan } from "./pddl/response_parser.js";
@@ -76,35 +76,29 @@ export class PddlPlanner {
     }
 
     /**
-     * Solve the crate-clearing maneuver from `entry` to `exit` using PDDL, with a cache.
+     * Solve the crate-clearing maneuver from `segment.entry` to `segment.exit` using PDDL, with a cache.
      * The PDDL problem uses the full map (no windowing) but anchors start=entry, goal=exit —
      * decoupling the maneuver from the agent's distant position and delivery target. This lets
      * the cache key (`entry + exit + nearby crate positions`) remain stable while the agent
      * approaches the cluster along the A* prefix, so moving 1 tile toward the cluster is a hit.
-     * @param entry Tile adjacent to the crate cluster; PDDL start.
-     * @param exit Tile just past the cluster; PDDL goal.
-     * @param clusterCrates Crates in the cluster bounding box, used to compute the cache key.
+     * @param segment The crate-blocked segment to clear, as returned by `findCrateSegment`.
      * @returns Parsed move/push steps (no terminal), or null if the solver fails.
      */
-    async solveManeuver(
-        entry: Position,
-        exit: Position,
-        clusterCrates: { id: string; position: Position }[],
-    ): Promise<PlanStep[] | null> {
-        // Build the cache key from entry+exit+cluster crate positions
+    async solveManeuver(segment: CrateSegment): Promise<PlanStep[] | null> {
+        const { entry, exit, clusterCrates } = segment;
         const key = [
             `${entry.x},${entry.y}`,
             `${exit.x},${exit.y}`,
-            clusterCrates.map(c => `${c.position.x},${c.position.y}`).sort().join(","),
+            clusterCrates.map(c => `${c.position.x},${c.position.y}`).sort().join("|"),
         ].join("|");
-        
+
         // Check cache for existing solution before invoking the solver
         const cached = this.maneuverCache.get(key);
         if (cached) {
             this.log.debug("Maneuver cache hit");
             return [...cached];
         }
-        
+
         // If not cached, build the problem and solve it
         const problem = buildProblem(exit, this.beliefs, entry);
         if (!problem) return null;

--- a/src/agents/bdi/plan/planner.ts
+++ b/src/agents/bdi/plan/planner.ts
@@ -1,7 +1,8 @@
-import { AStarPlanner } from "./astar_planner.js";
+import { AStarPlanner, TERMINAL_STEP } from "./astar_planner.js";
 import { PddlPlanner } from "./pddl_planner.js";
 import { Intentions } from "../intention/intentions.js";
-import { detectCrateBlock } from "../belief/utils/crate_block.js";
+import { detectCrateBlock, findCrateSegment } from "../belief/utils/crate_block.js";
+import { stepsTo } from "./navigation/a_star.js";
 import type { Beliefs } from "../belief/beliefs.js";
 import type { Position } from "../../../models/position.js";
 import type { Plan, PlanStep } from "../../../models/plan.js";
@@ -111,15 +112,39 @@ export class Planner {
                 return astarPlan;
             }
 
-            // A* failed — check if crates are blocking the route
-            const crateIds = detectCrateBlock(this.beliefs, from, desire);
-            if (crateIds) {
-                this.log.debug(`Crate block on ${desire.type} — falling back to PDDL`);
-                const pddlPlan = await this.pddlPlanner.plan(from, desire, crateIds);
+            // A* failed — check if crates are blocking the route and find the local cluster
+            const seg = findCrateSegment(this.beliefs, from, desire.target);
+            if (seg) {
+                // Try stitched A*/PDDL plan: A* to cluster entry, PDDL clears crates, A* to target.
+                // The PDDL maneuver is anchored at entry→exit (not agent position→target), making
+                // it independent of where the agent is and enabling cache reuse across re-deliberations.
+                const prefix = stepsTo(this.beliefs, from, seg.entry);
+                const maneuver = await this.pddlPlanner.solveManeuver(seg.entry, seg.exit, seg.clusterCrates);
+                const suffix = stepsTo(this.beliefs, seg.exit, desire.target);
+                if (prefix !== null && maneuver !== null && suffix !== null) {
+                    const terminal = TERMINAL_STEP[desire.type];
+                    const steps = [...prefix, ...maneuver, ...suffix];
+                    if (terminal) steps.push(terminal);
+                    this.log.debug(`Stitched plan for ${desire.type}: ${prefix.length} prefix + ${maneuver.length} maneuver + ${suffix.length} suffix steps`);
+                    return { source: "pddl", steps, cursor: 0, target: desire };
+                }
+                // Fallback: whole-trip PDDL if stitching fails (e.g. maneuver infeasible from entry)
+                this.log.debug(`Stitched plan failed for ${desire.type} — falling back to whole-trip PDDL`);
+                const pddlPlan = await this.pddlPlanner.plan(from, desire, seg.clusterCrates.map(c => c.id));
                 if (pddlPlan) return pddlPlan;
                 this.log.debug(`PDDL failed for ${desire.type} — dropping desire`);
             } else {
-                this.log.debug(`A* failed (no crate block) for ${desire.type} — dropping desire`);
+                // Push-aware path returned null: every reachable path through crates was via an
+                // immovable crate (wall behind it). However, a multi-step corridor case can slip
+                // through the single-step pushability check, so try the whole-trip PDDL once as
+                // a completeness backstop before dropping — at most 1 extra solve, not a loop.
+                const crateIds = detectCrateBlock(this.beliefs, from, desire);
+                if (crateIds) {
+                    this.log.debug(`Push-aware path failed for ${desire.type} — trying whole-trip PDDL (corridor backstop)`);
+                    const pddlPlan = await this.pddlPlanner.plan(from, desire, crateIds);
+                    if (pddlPlan) return pddlPlan;
+                }
+                this.log.debug(`A* failed (no viable crate path) for ${desire.type} — dropping desire`);
             }
 
             this.intentionManager.dropIntentionHead();

--- a/src/agents/bdi/plan/planner.ts
+++ b/src/agents/bdi/plan/planner.ts
@@ -119,7 +119,7 @@ export class Planner {
                 // The PDDL maneuver is anchored at entry→exit (not agent position→target), making
                 // it independent of where the agent is and enabling cache reuse across re-deliberations.
                 const prefix = stepsTo(this.beliefs, from, seg.entry);
-                const maneuver = await this.pddlPlanner.solveManeuver(seg.entry, seg.exit, seg.clusterCrates);
+                const maneuver = await this.pddlPlanner.solveManeuver(seg);
                 const suffix = stepsTo(this.beliefs, seg.exit, desire.target);
                 if (prefix !== null && maneuver !== null && suffix !== null) {
                     const terminal = TERMINAL_STEP[desire.type];

--- a/src/agents/bdi/plan/planner.ts
+++ b/src/agents/bdi/plan/planner.ts
@@ -120,12 +120,9 @@ export class Planner {
                 // it independent of where the agent is and enabling cache reuse across re-deliberations.
                 const prefix = stepsTo(this.beliefs, from, seg.entry);
                 const maneuver = await this.pddlPlanner.solveManeuver(seg);
-                const suffix = stepsTo(this.beliefs, seg.exit, desire.target);
-                if (prefix !== null && maneuver !== null && suffix !== null) {
-                    const terminal = TERMINAL_STEP[desire.type];
-                    const steps = [...prefix, ...maneuver, ...suffix];
-                    if (terminal) steps.push(terminal);
-                    this.log.debug(`Stitched plan for ${desire.type}: ${prefix.length} prefix + ${maneuver.length} maneuver + ${suffix.length} suffix steps`);
+                if (prefix !== null && maneuver !== null) {
+                    const steps = [...prefix, ...maneuver];
+                    this.log.debug(`Stitched plan for ${desire.type}: ${prefix.length} prefix + ${maneuver.length} maneuver steps`);
                     return { source: "pddl", steps, cursor: 0, target: desire };
                 }
                 // Fallback: whole-trip PDDL if stitching fails (e.g. maneuver infeasible from entry)

--- a/src/models/crate.ts
+++ b/src/models/crate.ts
@@ -9,3 +9,9 @@ export type Crate = {
     id: string;                     // Unique identifier for the crate
     lastPosition: Position | null;  // Position of the crate on the map
 };
+
+/** A crate whose position is known (resolved from `Crate.lastPosition`). */
+export type LocatedCrate = {
+    id: string;
+    position: Position;
+};

--- a/src/models/plan.ts
+++ b/src/models/plan.ts
@@ -7,6 +7,7 @@
 
 import type { Position } from "./position.js";
 import type { NavigationDesire } from "./desires.js";
+import type { LocatedCrate } from "./crate.js";
 
 export type MoveDirection = "up" | "down" | "left" | "right";
 
@@ -21,6 +22,14 @@ export type PlanStep =
     | { kind: "putdown" }; // executed at the tile where the agent stands
 
 export type PlanSource = "astar" | "pddl";
+
+/** The crate-blocked segment on a push-aware path, used as input to the PDDL maneuver solver. */
+export type CrateSegment = {
+    entry: Position;
+    exit: Position;
+    clusterCrates: LocatedCrate[];
+};
+
 
 export type Plan = {
     source: PlanSource;


### PR DESCRIPTION
## Fix PDDL crate-clearing: concurrent file collisions, maneuver caching, and dense-map replanning
  
  ### Problem

  Three separate issues were causing PDDL-assisted navigation to fail or produce incorrect behaviour:
  
  1. **Concurrent agent file collisions** — The local solver wrote domain/problem/plan files to fixed paths (`/tmp/domain.pddl`, `/tmp/problem.pddl`, `/tmp/plan`). In
  competitive/cooperative mode, two agents falling back to PDDL simultaneously would clobber each other's files, causing one of them to solve the wrong problem or read a stale
  plan.
  
  2. **No maneuver caching** — Every re-deliberation cycle while the agent was walking toward a crate cluster re-invoked the PDDL solver with an identical (or equivalent)
  problem, wasting solver time on redundant calls.

  3. **Stale suffix in dense maps** — The stitched plan (`prefix + maneuver + suffix`) computed the suffix A\* path at plan-build time, before the PDDL maneuver ran. In dense 
  maps, crates pushed during the maneuver could land on suffix tiles, leaving the agent trying to walk into newly blocked positions.

  ### Fixes
  
  **Concurrent file collisions** (`solver.ts`): replaced fixed `/tmp/*.pddl` paths with `mkdtempSync`-isolated temp directories, one per solver call. Also migrated from
  synchronous `spawnSync` to async `execFile` so the event loop is not blocked during solving.

  **Maneuver caching** (`pddl_planner.ts`, `problem_builder.ts`): introduced a FIFO `maneuverCache` (capacity 32) keyed by `entry | exit | sorted crate positions`. To make the
  key stable across re-deliberations, `buildProblem` was extended with an optional `from` parameter so the PDDL problem is anchored at the cluster entry tile rather than the
  agent's live position. This means every step the agent takes toward the cluster while holding a PDDL plan is a cache hit, not a new solve.
  
  **Dense-map suffix problem** (`planner.ts`): removed the suffix from the stitched plan. The plan is now `prefix + maneuver` only. After the maneuver completes, the intention
  head is preserved (existing PDDL behaviour) and the next deliberation cycle replans from `exit` with accurate post-push crate beliefs — chaining naturally through multiple
  segments without stale-path issues.